### PR TITLE
am/add hyperparams

### DIFF
--- a/D3MUnsupervised/Hdbscan.py
+++ b/D3MUnsupervised/Hdbscan.py
@@ -119,8 +119,7 @@ class Hdbscan(TransformerPrimitiveBase[Inputs, Outputs, Hyperparams]):
         ----------
         Outputs
             The output is a dataframe containing a single column where each entry is the associated series' cluster number.
-        """
-        print('Code Changed')    
+        """ 
     
         hyperparams_class = DatasetToDataFrame.DatasetToDataFramePrimitive.metadata.query()['primitive_code']['class_type_arguments']['Hyperparams']
         ds2df_client = DatasetToDataFrame.DatasetToDataFramePrimitive(hyperparams = hyperparams_class.defaults().replace({"dataframe_resource":"learningData"}))


### PR DESCRIPTION
added a cluster_selection_method hyperparam to hdbscan.py. Set the default to 'leaf' which is more likely to produce smaller more homogeneous clusters, and results in at least some clusters in several data sets when experimenting in notebooks. Checked it runs in the pipelines, although it doesn't improve 'sylva' data set predictions.  